### PR TITLE
docs(prompts): add Phase 6 quality assessment and writing-prompts guide addendum

### DIFF
--- a/prompts/phase6-implementation-quality-and-phase-d-readiness-assessment-2026-03-27.md
+++ b/prompts/phase6-implementation-quality-and-phase-d-readiness-assessment-2026-03-27.md
@@ -1,0 +1,181 @@
+# Phase 6 Implementation Quality and Phase D Readiness Assessment
+
+_Date: 2026-03-27_
+_Reviewer: Coding agent synthesis of architecture docs, plans, changelog, bugs/lessons, prompt workflow, and Phase 6 prompt audits._
+
+---
+
+## 1) Executive Assessment
+
+**Overall verdict:** **Phase 6 implementation quality is strong and functionally complete**, with substantial evidence of contract alignment, test expansion, and post-merge hardening. The implementation appears to have delivered all planned v7.5.6.0–v7.5.6.4 outcomes.
+
+**Confidence level:** High for feature completeness, medium-high for operational robustness.
+
+**Readiness for Phase D:** **Conditionally ready**.
+
+- ✅ Ready from a feature/platform perspective (ingest, system category, system renderer, fixtures/tests, closure docs are present).
+- ⚠️ Not fully ready from a workflow/control perspective because at least one orchestration artifact still describes Phase 6 steps as pending, which can cause operator error.
+
+---
+
+## 2) Evidence-Based Delivery Accuracy vs Plan
+
+## 2.1 Planned scope (Phase 6 plan)
+
+The implementation plan defines five steps:
+
+1. v7.5.6.0 ingest endpoint (`POST /api/ingest/{device}/{metric}?val={float}`)
+2. v7.5.6.1 system category + `external_push`
+3. v7.5.6.2 system card renderer + `/api/v2/live` update path
+4. v7.5.6.3 exporter scripts + ingest docs
+5. v7.5.6.4 fixtures, Playwright, closure
+
+It also emphasizes RAM-only history for new metric categories and no initial auth hardening for ingest (documented limitation).
+
+## 2.2 Delivered scope (changelog + audits)
+
+Changelog entries show all five steps completed on 2026-03-26 with concrete artifacts:
+
+- v7.5.6.0 ingest endpoint
+- v7.5.6.1 system device and manifest/generator changes
+- v7.5.6.2 system renderer and live updates
+- v7.5.6.3 bash/python exporters + setup documentation
+- v7.5.6.4 system fixture variant, mixed fixture update, Group 20 tests, CI matrix update, closure
+
+The audit reports for PRs #78, #82, #83, #84, and #87 consistently show that merge-time review comments were resolved and critical issues closed before or at merge.
+
+## 2.3 Accuracy conclusion
+
+**Implementation accuracy is high**: delivered work maps tightly to planned work by step, including generated artifacts, tests, and closure paperwork.
+
+---
+
+## 3) Most Valuable Lessons from Phase 6
+
+## 3.1 Prompt quality directly controls defect rate
+
+Across v7.5.6.2, v7.5.6.3, and v7.5.6.4 audits, many defects were attributed to prompt under-specification or prompt-provided buggy code snippets rather than freeform agent invention.
+
+**High-value takeaway:** Prompt text must be treated as production code/spec. If snippets are wrong, implementation will be wrong quickly and consistently.
+
+## 3.2 Data-path completeness beats surface completeness
+
+The strongest failure pattern was omitted runtime link(s): e.g., generation/runtime trigger paths and aggregator update paths not always explicitly traced. Prompts that traced source → transport → state update → DOM/test assertion performed better.
+
+**High-value takeaway:** Require full path tracing in every implementation prompt and every prompt audit.
+
+## 3.3 Contract-faithful mocks are mandatory
+
+PR #87 showed a recurrent trap: mocks that start as “happy path + unknown device” are insufficient for endpoint contract testing. Metric-key and `val` validation had to be added in follow-up commits.
+
+**High-value takeaway:** Mocks must mirror production validation branches and response schemas.
+
+## 3.4 Fixture composition changes have ripple effects
+
+When mixed/system fixture composition changed, stale skip reasons/comments lingered until review.
+
+**High-value takeaway:** Any fixture cardinality/composition edit must trigger a textual audit of skip reasons/comments and helper assumptions.
+
+## 3.5 Defensive coding patterns should be enforced at prompt level
+
+Late fixes such as null-safe checks, HTML escaping, `isFinite` guards, locale normalization, sanitization, and context-managed HTTP calls were all predictable.
+
+**High-value takeaway:** Defensive standards should be explicit checklist items in prompts, not optional reviewer improvements.
+
+---
+
+## 4) Pitfalls Ahead Before / During Phase D
+
+## 4.1 Workflow drift between canonical tracking documents
+
+`prompts/prompt-index-and-workflow.md` still marks v7.5.6.2–v7.5.6.4 as pending in the Phase 6 index, while changelog and session history indicate completion.
+
+**Risk:** Operators or agents may select incorrect next steps, re-run completed work, or mis-sequence tagging and testing.
+
+## 4.2 Runtime mutability introduces concurrency risk
+
+Phase D shifts from compile-time static satellite arrays toward runtime add/remove operations with NVS persistence and background polling.
+
+**Risk areas called out by plan:**
+- mutex discipline across mutation + polling
+- loop bounds migration from `MAX_SATELLITES` to runtime count
+- dense array compaction and persistence consistency
+
+## 4.3 API input and contract parity risk for new endpoints
+
+Phase D introduces multiple management endpoints (`add`, `delete`, `test`) with validation and probing.
+
+**Likely pitfall:** repeating Phase 6-style under-specification in mock/server/test contracts, especially around error branches and status codes.
+
+## 4.4 Backward-compatibility and fallback semantics risk
+
+Phase D requires clean bootstrap behavior: use NVS list when present, else compile-time fallback.
+
+**Likely pitfall:** one-way migration assumptions, incomplete fallback testing, or silent breakage on previously flashed boards.
+
+## 4.5 Test-matrix explosion and skip-fragility
+
+As runtime satellite management arrives, fixture states will multiply (empty NVS, seeded NVS, duplicate URL, full list, unreachable URL, etc.).
+
+**Likely pitfall:** shallow tests that pass under one seeded path but fail under true CI matrix conditions.
+
+---
+
+## 5) Is the Current Stage Ready for Phase D?
+
+## 5.1 What is ready
+
+- Core Phase 6 capabilities and tests are present.
+- Phase D implementation plan exists with concrete endpoint and storage design.
+- Aggregator principles and architecture references exist.
+
+## 5.2 What is still missing (beyond “Phase D prompts”)
+
+1. **Workflow source-of-truth reconciliation**
+   - Update prompt index Phase 6 status to complete to match reality.
+
+2. **Phase D preflight/validation contract definition before coding**
+   - Exact CI-equivalent commands for each new endpoint and fixture state.
+   - Explicit test matrix for NVS empty/seeded/overflow/dup/unreachable scenarios.
+
+3. **Mock-contract lock template for Phase D endpoint prompts**
+   - Require full branch parity with firmware handler behavior.
+
+4. **State-mutation safety checklist embedded into every Phase D prompt**
+   - Mutex usage, runtime count bounds, compaction invariants, persistence atomicity.
+
+5. **Backward-compatibility test checklist**
+   - “fresh flash”, “upgrade from pre-Phase D”, and “reboot persistence” must be explicit acceptance gates.
+
+6. **Operational rollback note in prompts/session handoff**
+   - Clear instructions for recovering from corrupted runtime satellite config (e.g., NVS clear strategy) before rolling forward.
+
+## 5.3 Final readiness decision
+
+**Recommendation: GO for Phase D prompt authoring and preflight hardening first, then implementation.**
+
+Do not start coding Phase D until the six missing control items above are incorporated into the prompt workflow.
+
+---
+
+## 6) Suggested Action List (Short)
+
+1. Update prompt index Phase 6 status rows to ✅ complete.
+2. Add a shared “contract-faithful mock” checklist block to all Phase D prompts.
+3. Add a shared “runtime mutation safety” checklist block to all Phase D prompts.
+4. Define and pin CI-exact validation command sets for each Phase D step.
+5. Add explicit upgrade/fallback test cases to every Phase D acceptance section.
+
+---
+
+## 7) Source Set Reviewed
+
+- `prompts/prompt-index-and-workflow.md`
+- `prompts/phase6/*PR*-consolidated-audit-and-lessons.md`
+- `Docs/changelog.md`
+- `Docs/bugs-and-lessons-learned.md`
+- `Docs/v7.5-v7.6-architecture-plan.md`
+- `Docs/phase6-implementation-plan.md`
+- `Docs/phase-d-implementation-plan.md`
+- `Docs/aggregator-satellite-gateway-principles.txt`
+- `Docs/writing-prompts-for-coding-agents-guide.md`

--- a/prompts/writing-prompts-guide-addendum-phase6-audit-2026-03-27.md
+++ b/prompts/writing-prompts-guide-addendum-phase6-audit-2026-03-27.md
@@ -1,0 +1,170 @@
+# Addendum to `Docs/writing-prompts-for-coding-agents-guide.md`
+## Phase 6 Prompt-Audit Derived Improvements
+
+_Date: 2026-03-27_
+_Based on: Phase 6 consolidated audits for PR #78/#82/#83/#84/#87 and current guide content._
+
+---
+
+## Purpose
+
+This addendum defines concrete updates that should be merged into the guide so future prompts avoid the recurring failure modes seen in Phase 6.
+
+---
+
+## A) New Section to Add: “Prompt-Provided Code Must Be Production-Quality”
+
+### Why
+
+Phase 6 audits repeatedly show that agents implemented prompt snippets accurately, including defects. A large share of review findings were prompt-authored bugs propagated into code.
+
+### Add to guide
+
+Add a section (suggested placement after current §3.2) with this rule:
+
+> Any code block provided in a prompt is normative implementation guidance and must pass the same quality bar as production code before prompt publication.
+
+Include minimum checks by language:
+
+- **Python:** imports at module scope, context managers for network/file handles, docstrings match behavior.
+- **Shell:** locale-stable parsing (`LC_ALL=C`), input sanitization before URL interpolation.
+- **JavaScript:** `escHtml()` for config/manifest text sinks, explicit null checks, `isFinite()` for numeric-to-CSS transforms.
+
+---
+
+## B) Expand Gap Taxonomy with Five New/Clarified Gaps
+
+## Gap 14 — Inconsistent Guard Style in Prompt Snippets
+
+### Why
+
+v7.5.6.2 surfaced mixed guard styles (`truthy` vs explicit null/undefined) causing logic bugs.
+
+### Add to guide
+
+- Ban mixed presence-check idioms in a function body.
+- Preferred standard for optional numeric/time fields: `value !== undefined && value !== null`.
+
+## Gap 15 — Prompt-Seeded Security Sink
+
+### Why
+
+v7.5.6.2 had unescaped manifest-derived text in generated HTML path.
+
+### Add to guide
+
+- Any untrusted/config-derived string inserted into HTML must be escaped at sink.
+- Prompt must list each sink in scope and expected sanitizer.
+
+## Gap 16 — Numeric-to-CSS Without Finite Guard
+
+### Why
+
+v7.5.6.2 allowed NaN to propagate into style width (`"NaN%"`).
+
+### Add to guide
+
+- Any function mapping numeric input to CSS/DOM geometry must early-return unless `isFinite(value)`.
+
+## Gap 17 — Under-Specified Contract Mocks
+
+### Why
+
+v7.5.6.4 mock endpoint initially validated only device existence, not full contract branches.
+
+### Add to guide
+
+- Mock prompts must include contract-lock checklist:
+  1. source firmware handler to mirror,
+  2. all positive/negative branches,
+  3. exact success/error JSON shapes,
+  4. one test per branch,
+  5. explicit “no stub simplification” rule.
+
+## Gap 18 — Fixture Composition Ripple Omissions
+
+### Why
+
+v7.5.6.4 changed fixture composition but left stale skip rationale text/comments.
+
+### Add to guide
+
+- Any fixture cardinality/composition change requires downstream text audit:
+  - `test.skip()` reasons,
+  - group headers/comments,
+  - helper expectations/hardcoded counts.
+
+---
+
+## C) Additions to the Prompt Author Pre-Flight Checklist (§9)
+
+Add the following checks:
+
+1. **Snippet lint pass:** Run lint/static checks on prompt-provided snippets before prompt release.
+2. **Contract-fidelity pass for mocked endpoints:** Verify branch parity against firmware handler.
+3. **Sanitization pass:** Confirm all config/manifest-to-HTML insertions are escaped.
+4. **Finite-number pass:** Confirm `isFinite` (or equivalent) exists for numeric-to-style/UI code.
+5. **Locale pass for shell parsing:** Confirm `LC_ALL=C` on locale-sensitive commands.
+6. **Interpolation sanitization pass:** Strip non-numeric characters before metric URL query injection.
+7. **Resource-lifecycle pass:** Confirm network/file handles are explicitly closed or context-managed.
+8. **Fixture ripple pass:** After fixture changes, update dependent reason strings/comments.
+9. **Playwright fixture hygiene pass:** Remove unused `{ page, request, ... }` destructured fixtures.
+
+---
+
+## D) Additions to Test Group Guardrails (§3.11)
+
+Add two mandatory bullets:
+
+1. After fixture composition changes, search all skip reasons/comments for stale counts and update them.
+2. Require destructured Playwright fixtures to be minimal and used.
+
+---
+
+## E) Additions to “Common Anti-Patterns” (§10)
+
+Add these anti-patterns:
+
+- “Prompt snippet compiles, therefore prompt is good” (false confidence).
+- “Mock only happy-path + unknown device” for contract endpoints.
+- “Copy reference code without re-auditing latent bugs.”
+- “Use truthy checks for numeric/time values.”
+- “Interpolate parsed shell output into URLs without sanitization.”
+
+---
+
+## F) Proposed Compact Template Block for Future Prompts
+
+Add reusable template text:
+
+```md
+### Contract-Lock (Mandatory for endpoint mocks)
+- Read firmware handler: <file:function>
+- Implement all branches: success + each validation failure
+- Match JSON response shape exactly
+- Add one test per branch
+- Do NOT implement a stub (e.g., device-exists-only)
+
+### Snippet Quality Gates (Mandatory when prompt includes code)
+- [ ] JS: escHtml sinks audited
+- [ ] JS: null/undefined guards consistent
+- [ ] JS: isFinite guard for numeric->CSS
+- [ ] Shell: LC_ALL=C + metric sanitization
+- [ ] Python: module-level imports + context managers
+- [ ] Docs/comments aligned with actual behavior
+```
+
+---
+
+## G) Priority Order for Updating the Guide
+
+1. Add **Contract-Lock** and **Snippet Quality Gates** sections (highest ROI).
+2. Add Gap 17 and Gap 18 taxonomy entries.
+3. Add checklist items to §9 and §3.11.
+4. Add anti-pattern bullets for quick reviewer scanning.
+
+---
+
+## H) Expected Outcome if Applied
+
+If these updates are integrated, prompt quality should shift from “structurally strong but occasionally under-specified” to “structurally strong and execution-robust,” reducing multi-round review churn and lowering prompt-seeded defect injection in future phases (especially Phase D runtime management work).


### PR DESCRIPTION
### Motivation

- Provide an evidence-based assessment of Phase 6 implementation quality and a readiness decision for Phase D based on the changelog, plans, bugs/lessons, and consolidated prompt audits.
- Capture recurring prompt-driven failure modes observed during Phase 6 so prompt authors and reviewers can avoid repeat defects in Phase D.
- Produce a concrete addendum to `Docs/writing-prompts-for-coding-agents-guide.md` with actionable guardrails and checklist items derived from the Phase 6 audits.

### Description

- Added `prompts/phase6-implementation-quality-and-phase-d-readiness-assessment-2026-03-27.md` which synthesizes Phase 6 delivery evidence, lessons learned, likely pitfalls for Phase D, and an explicit recommendation to prepare prompt-level preflight controls before coding Phase D.
- Added `prompts/writing-prompts-guide-addendum-phase6-audit-2026-03-27.md` which proposes concrete guide updates: new gap categories (guard style, mock fidelity, fixture ripple, numeric-to-CSS guards, security sinks), expanded pre-flight checklist items, test-group guardrail additions, anti-patterns, and a reusable `Contract-Lock` / `Snippet Quality Gates` template block for future prompts.
- Committed both docs and opened a PR titled `docs(prompts): add Phase 6 quality assessment and prompt-guide addendum`; this is a documentation-only change that does not modify runtime code.

### Testing

- This is a documentation-only change; no unit or integration tests were required or modified for runtime code.
- Verified added files and basic visibility in the repo with the commands used during the change: `git status --short`, and `nl -ba` / `sed -n` checks for the new prompt files and related references (these checks succeeded locally prior to committing).
- Commit created: `docs(prompts): add phase6 quality assessment and writing-guide addendum` and PR prepared with validation notes in the PR body; no CI-facing code changes were included.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5eb0b4e648325b549e56aa8e6e292)