### PR TITLE
Add incident report: HTTPD POST zero-length crash and reboot loop (v7.6.0.0)

### DIFF
--- a/Docs/session-log-2026-03-30-v7.6.0.0-httpd-post-crash-report.md
+++ b/Docs/session-log-2026-03-30-v7.6.0.0-httpd-post-crash-report.md
@@ -17,7 +17,7 @@ _Target: ESP32-S3 aggregator (`192.168.120.191`)_
 
 ### B) POST requests without `Content-Length` do not crash (clean 411)
 - Reproducible with:
-  - `curl -v -X POST -u ESPadmin:ESppass100 http://192.168.120.191/api/system/reset-satellites`
+  - `curl -v -X POST -u -u <user>:<password> http://192.168.120.191/api/system/reset-satellites`
 - Result:
   - `HTTP/1.1 411 Length Required`
   - ESPHome log warning: `Content length is required for post: /api/system/reset-satellites`
@@ -126,13 +126,13 @@ Apply to:
 
 Run the following matrix after implementing Fix A + Fix B:
 
-1. `curl -v -X POST -d '' -u ESPadmin:ESppass100 http://192.168.120.191/api/system/reset-satellites`
+1. `curl -v -X POST -d '' -u <user>:<password> http://192.168.120.191/api/system/reset-satellites`
    - Expected: no crash; controlled HTTP response.
 
-2. `curl -v -X POST -u ESPadmin:ESppass100 http://192.168.120.191/api/system/reset-satellites`
+2. `curl -v -X POST -u <user>:<password> http://192.168.120.191/api/system/reset-satellites`
    - Expected: 411 or controlled error; no crash.
 
-3. `curl -v -X POST -d '{}' -H 'Content-Type: application/json' -u ESPadmin:ESppass100 http://192.168.120.191/api/reboot`
+3. `curl -v -X POST -d '{}' -H 'Content-Type: application/json' -u <user>:<password> http://192.168.120.191/api/reboot`
    - Expected: intentional reboot only; no panic pre-reboot.
 
 4. Dashboard open + reboot button


### PR DESCRIPTION
### Motivation
- Document a reproducible crash where `POST` requests with `Content-Length: 0` trigger an `httpd` panic and reboot loop on an ESP32-S3 aggregator, capture serial evidence and backtraces, and collate immediate mitigations. 
- Record investigation findings, primary suspicions, and a prioritized set of fixes including frontend request-shape hardening and firmware-side defensive guards. 
- Preserve the tested `sdkconfig` profile changes and YAML regeneration steps to ensure the incident context is reproducible. 

### Description
- Add `Docs/session-log-2026-03-30-v7.6.0.0-httpd-post-crash-report.md` containing the full incident timeline, reproducible `curl` commands, serial logs, root-cause analysis, and recommended fixes. 
- Include reproduced behaviors distinguishing `POST` with `Content-Length: 0` (crash) from `POST` without `Content-Length` (411 response), and capture dashboard-open reboot loop observations. 
- Document immediate remediation guidance including a frontend `fetch` pattern that sends `body: '{}'` with `Content-Type: application/json`, firmware-side early POST validation, and continued `sdkconfig` profile hardening. 

### Testing
- No automated tests were added or run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caa8bd46f88325a4237de51b99567f)