### PR TITLE
docs: BUG-082 + LESSON-OPS-127 — document reserve≠truncation limitati…

### DIFF
--- a/Docs/bugs-and-lessons-learned.md
+++ b/Docs/bugs-and-lessons-learned.md
@@ -10,21 +10,3 @@ _See `Docs/lessons/index.md` for the complete cross-reference._
 | Build Pipeline | `Docs/lessons/build-pipeline.md` |
 | Testing | `Docs/lessons/testing.md` |
 | Operations | `Docs/lessons/operations.md` |
-
-## Latest Operational Addendum
-
-- `LESSON-OPS-126` moved into `Docs/lessons/operations.md`: checkpoint grep assertions must be validated against the actual replacement block in the same prompt.
-- Critical Rule: checkpoint grep counts must be mechanically derived from the replacement block in the same prompt, not estimated from memory.
-
-### BUG-082: `csv.reserve(cap)` does not truncate - string grows unbounded past reserved capacity (v7.6.9.4)
-
-**Symptom:** WROOM board (192.168.120.190) crashes with heap exhaustion when serving `/history/{id}/temp` or when dashboard loads history at boot, despite v7.6.9.4 adaptive cap computing a safe reserve value of ~12 KB.
-
-**Root cause:** `std::string::reserve(N)` pre-allocates capacity N but does NOT prevent the string from growing beyond N through `.append()` calls. The NVS scan loop in `handle_history_()` (`firmware/core/web-handler.h`) appended ~40 KB of CSV data (556 segments x 4 points x ~18 bytes/line) into a string reserved at 12 KB, triggering repeated reallocations. During reallocation from ~24 KB -> ~48 KB, `std::string` temporarily holds both old and new buffers (72 KB total), exceeding the WROOM's ~34 KB free heap.
-
-**Resolution:** Deferred to Phase 7. The proper fix is chunked HTTP streaming - serving NVS segments in paged responses (~3.6 KB each) instead of building the full CSV in RAM. A simple truncation guard (`break` when `csv.size() >= adaptive_cap`) was considered but rejected because it would truncate history display on ALL boards (including C3) as their NVS fills up, not just WROOM.
-
-**Data safety:** NVS data is intact on flash. Raw partition backup extracted via `esptool read_flash 0x370000 0x80000`. Offline parser script (`scripts/parse_nvs_history.py`) available for extraction.
-
-**Lesson:** `reserve()` is an allocation optimization, not a size constraint. Any time a `reserve()` cap is introduced as a safety net for heap-constrained boards, verify whether the subsequent append loops actually enforce the cap as a truncation limit. See LESSON-OPS-127.
-

--- a/Docs/bugs-and-lessons-learned.md
+++ b/Docs/bugs-and-lessons-learned.md
@@ -15,3 +15,16 @@ _See `Docs/lessons/index.md` for the complete cross-reference._
 
 - `LESSON-OPS-126` moved into `Docs/lessons/operations.md`: checkpoint grep assertions must be validated against the actual replacement block in the same prompt.
 - Critical Rule: checkpoint grep counts must be mechanically derived from the replacement block in the same prompt, not estimated from memory.
+
+### BUG-082: `csv.reserve(cap)` does not truncate - string grows unbounded past reserved capacity (v7.6.9.4)
+
+**Symptom:** WROOM board (192.168.120.190) crashes with heap exhaustion when serving `/history/{id}/temp` or when dashboard loads history at boot, despite v7.6.9.4 adaptive cap computing a safe reserve value of ~12 KB.
+
+**Root cause:** `std::string::reserve(N)` pre-allocates capacity N but does NOT prevent the string from growing beyond N through `.append()` calls. The NVS scan loop in `handle_history_()` (`firmware/core/web-handler.h`) appended ~40 KB of CSV data (556 segments x 4 points x ~18 bytes/line) into a string reserved at 12 KB, triggering repeated reallocations. During reallocation from ~24 KB -> ~48 KB, `std::string` temporarily holds both old and new buffers (72 KB total), exceeding the WROOM's ~34 KB free heap.
+
+**Resolution:** Deferred to Phase 7. The proper fix is chunked HTTP streaming - serving NVS segments in paged responses (~3.6 KB each) instead of building the full CSV in RAM. A simple truncation guard (`break` when `csv.size() >= adaptive_cap`) was considered but rejected because it would truncate history display on ALL boards (including C3) as their NVS fills up, not just WROOM.
+
+**Data safety:** NVS data is intact on flash. Raw partition backup extracted via `esptool read_flash 0x370000 0x80000`. Offline parser script (`scripts/parse_nvs_history.py`) available for extraction.
+
+**Lesson:** `reserve()` is an allocation optimization, not a size constraint. Any time a `reserve()` cap is introduced as a safety net for heap-constrained boards, verify whether the subsequent append loops actually enforce the cap as a truncation limit. See LESSON-OPS-127.
+

--- a/Docs/changelog.md
+++ b/Docs/changelog.md
@@ -17,6 +17,12 @@ All notable changes to the ESP32-C3 Multi-Sensor BLE Gateway.
 - Checkpoint A passed: both reserve sites now use `adaptive_cap`, the fixed `60000` reserve pattern is gone, and no other firmware file changed before the client edit.
 - Checkpoint B passed under the updated prompt assertions from `origin/main`; the new history bootstrap gate, fallback timer binding, and old 10 s binding removal are all present.
 
+### Known Limitation (documented 2026-04-18)
+
+- The adaptive `csv.reserve()` cap does not truncate CSV output - the NVS scan loop grows the string past the cap through unbounded appending. WROOM boards with ~34 KB free heap and large NVS history (500+ segments) will still crash on `/history/{id}/{series}` and on dashboard boot history load. Full fix deferred to Phase 7 chunked HTTP streaming. See BUG-082.
+
+- Raw NVS partition backup extracted via `esptool read_flash 0x370000 0x80000` for offline parsing.
+
 ## [v7.6.9.3] - 2026-04-17 - Phase V V3-F: Struct Audit / Phase V Closure
 
 ### Changed

--- a/Docs/lessons/firmware.md
+++ b/Docs/lessons/firmware.md
@@ -529,6 +529,22 @@ the DELETE satellite endpoint added in PR #110 (v7.6.0.2).
 
 **Fixed by:** PR #114. See LESSON-OPS-108, LESSON-OPS-109.
 
+
+---
+
+### BUG-082: `csv.reserve(cap)` does not truncate - string grows unbounded past reserved capacity (v7.6.9.4)
+
+**Symptom:** WROOM board (192.168.120.190) crashes with heap exhaustion when serving `/history/{id}/temp` or when dashboard loads history at boot, despite v7.6.9.4 adaptive cap computing a safe reserve value of ~12 KB.
+
+**Root cause:** `std::string::reserve(N)` pre-allocates capacity N but does NOT prevent the string from growing beyond N through `.append()` calls. The NVS scan loop in `handle_history_()` (`firmware/core/web-handler.h`) appended ~40 KB of CSV data (556 segments x 4 points x ~18 bytes/line) into a string reserved at 12 KB, triggering repeated reallocations. During reallocation from ~24 KB -> ~48 KB, `std::string` temporarily holds both old and new buffers (72 KB total), exceeding the WROOM's ~34 KB free heap.
+
+**Resolution:** Deferred to Phase 7. The proper fix is chunked HTTP streaming - serving NVS segments in paged responses (~3.6 KB each) instead of building the full CSV in RAM. A simple truncation guard (`break` when `csv.size() >= adaptive_cap`) was considered but rejected because it would truncate history display on ALL boards (including C3) as their NVS fills up, not just WROOM.
+
+**Data safety:** NVS data is intact on flash. Raw partition backup extracted via `esptool read_flash 0x370000 0x80000`. Offline parser script (`scripts/parse_nvs_history.py`) available for extraction.
+
+**Lesson:** `reserve()` is an allocation optimization, not a size constraint. Any time a `reserve()` cap is introduced as a safety net for heap-constrained boards, verify whether the subsequent append loops actually enforce the cap as a truncation limit. See LESSON-OPS-127.
+
+
 ---
 
 ## Lessons Learned

--- a/Docs/lessons/index.md
+++ b/Docs/lessons/index.md
@@ -88,6 +88,7 @@ This index lists every BUG and LESSON-OPS entry and its domain file location.
 | BUG-079 | firmware.md |
 | BUG-080 | dashboard.md |
 | BUG-081 | dashboard.md |
+| BUG-082 | firmware.md |
 | LESSON-OPS-001 | build-pipeline.md |
 | LESSON-OPS-002 | build-pipeline.md |
 | LESSON-OPS-003 | testing.md |
@@ -210,3 +211,5 @@ This index lists every BUG and LESSON-OPS entry and its domain file location.
 | LESSON-OPS-123 | build-pipeline.md |
 | LESSON-OPS-124 | build-pipeline.md |
 | LESSON-OPS-125 | firmware.md |
+| LESSON-OPS-126 | operations.md |
+| LESSON-OPS-127 | operations.md |

--- a/Docs/lessons/operations.md
+++ b/Docs/lessons/operations.md
@@ -104,3 +104,23 @@ The prompt's removal check was `git diff ... | grep -c '^-.*historyBootstrapTime
 
 Before finalising any checkpoint assertion of the form `grep -c SYMBOL FILE - expected: N`, count the literal occurrences of `SYMBOL` in the replacement or removal block defined in the same prompt document. If the block spans multiple lines, verify that the grep pattern can match across a single line; if the verification requires detecting a token removed from one line and another token removed from a different line, use separate single-token greps rather than a combined pattern. A wrong expected count is an instruction inconsistency that forces correct agent implementations to stop and escalate.
 
+### LESSON-OPS-127: std::string::reserve() is an allocation hint, not a size constraint (2026-04-18)
+
+`std::string::reserve(N)` pre-allocates capacity for N bytes but does not prevent the string from growing past N through `.append()` or `+=` calls. On heap-constrained ESP32 boards, this distinction is critical: the initial `reserve()` may fit in free heap, but unbounded appending triggers reallocations that temporarily require 2x the current string size (old + new buffer), which can exceed available memory.
+
+**Pattern for heap-safe string building in loops:**
+
+```cpp
+size_t cap = compute_safe_cap(esp_get_free_heap_size());
+std::string csv;
+csv.reserve(std::min(est_bytes, cap));
+for (each_item) {
+    if (csv.size() >= cap) break;   // MANDATORY truncation guard
+    append_data(csv, item);
+}
+```
+
+Without the break guard, the reserve() cap is cosmetic - the string grows unbounded and the board crashes during reallocation.
+
+Context: BUG-082 (v7.6.9.4). Both GitHub Copilot and OpenAI Codex automated reviews independently identified this defect. The fix is deferred to Phase 7 (chunked HTTP streaming replaces single-response CSV building entirely).
+

--- a/Docs/lessons/operations.md
+++ b/Docs/lessons/operations.md
@@ -104,7 +104,13 @@ The prompt's removal check was `git diff ... | grep -c '^-.*historyBootstrapTime
 
 Before finalising any checkpoint assertion of the form `grep -c SYMBOL FILE - expected: N`, count the literal occurrences of `SYMBOL` in the replacement or removal block defined in the same prompt document. If the block spans multiple lines, verify that the grep pattern can match across a single line; if the verification requires detecting a token removed from one line and another token removed from a different line, use separate single-token greps rather than a combined pattern. A wrong expected count is an instruction inconsistency that forces correct agent implementations to stop and escalate.
 
+---
+
+---
+
 ### LESSON-OPS-127: std::string::reserve() is an allocation hint, not a size constraint (2026-04-18)
+
+Context: BUG-082 (v7.6.9.4). Both GitHub Copilot and OpenAI Codex automated reviews independently identified this defect. The fix is deferred to Phase 7 (chunked HTTP streaming replaces single-response CSV building entirely).
 
 `std::string::reserve(N)` pre-allocates capacity for N bytes but does not prevent the string from growing past N through `.append()` or `+=` calls. On heap-constrained ESP32 boards, this distinction is critical: the initial `reserve()` may fit in free heap, but unbounded appending triggers reallocations that temporarily require 2x the current string size (old + new buffer), which can exceed available memory.
 
@@ -121,6 +127,4 @@ for (each_item) {
 ```
 
 Without the break guard, the reserve() cap is cosmetic - the string grows unbounded and the board crashes during reallocation.
-
-Context: BUG-082 (v7.6.9.4). Both GitHub Copilot and OpenAI Codex automated reviews independently identified this defect. The fix is deferred to Phase 7 (chunked HTTP streaming replaces single-response CSV building entirely).
 

--- a/Docs/phase-V-implementation-plan-addendum-v7.6.9.4.md
+++ b/Docs/phase-V-implementation-plan-addendum-v7.6.9.4.md
@@ -223,3 +223,14 @@ When this addendum merges:
 ---
 
 _End of Phase V plan addendum for v7.6.9.4._
+
+## Post-Merge Correction (2026-04-18)
+
+The adaptive cap as implemented controls only `std::string::reserve()` - an allocation hint. It does **not** enforce a hard truncation limit on the CSV data appended by the NVS scan loop. The string grows unbounded past the reserved capacity through `.append()` calls, and on the WROOM with 556 NVS segments (~40 KB CSV vs ~34 KB free heap), the reallocation spike crashes the board.
+
+Both GitHub Copilot and OpenAI Codex automated PR reviews independently identified this defect.
+
+**Decision:** Merge as-is, defer the fix to Phase 7. Chunked HTTP streaming (the Phase 7 transport fix) eliminates single-response CSV building entirely, making the truncation guard unnecessary. A truncation guard alone would cap history display on all boards as NVS fills - an undesirable universal behavioral change.
+
+**Data safety:** NVS data is intact on flash. Raw partition dump (`esptool read_flash 0x370000 0x80000`) extracted 2026-04-18 and parsed offline via `scripts/parse_nvs_history.py`.
+


### PR DESCRIPTION
…on (v7.6.9.4)

Post-merge documentation for PR #193. The adaptive csv.reserve() cap does

not enforce truncation — the NVS scan loop grows the string past the cap

through unbounded appending, crashing WROOM boards with large history.

Deferred to Phase 7 chunked HTTP streaming.